### PR TITLE
[Bug Fix] Removing b from plt.grid

### DIFF
--- a/tensorflow-mnist-tutorial/keras_01_mnist.ipynb
+++ b/tensorflow-mnist-tutorial/keras_01_mnist.ipynb
@@ -156,7 +156,7 @@
     "  digits = np.reshape(digits, [28, 28*n])\n",
     "  plt.yticks([])\n",
     "  plt.xticks([28*x+14 for x in range(n)], predictions)\n",
-    "  plt.grid(b=None)\n",
+    "  plt.grid(None)\n",
     "  for i,t in enumerate(plt.gca().xaxis.get_ticklabels()):\n",
     "    if predictions[i] != labels[i]: t.set_color('red') # bad predictions in red\n",
     "  plt.imshow(digits)\n",


### PR DESCRIPTION
The plt.grid(b=None) statement is causing the issue. The b argument in plt.grid() is used to specify whether to show the grid lines or not. When b is set to None, it tries to toggle the grid state, but Colab through this error `ValueError: keyword grid_b is not recognized; valid keywords`.